### PR TITLE
haxelib.json: improved description

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -3,7 +3,7 @@
 	"url" : "http://haxeflixel.com",
 	"license": "MIT",
 	"tags": ["game", "openfl", "flash", "neko", "cpp", "android", "ios", "cross"],
-	"description": "HaxeFlixel is a 2D game framework based on OpenFL that delivers cross-platform games.",
+	"description": "A cross-platform, 2D game engine based on OpenFL",
 	"version": "3.3.8",
 	"releasenote": "Use lime legacy with OpenFL 3+",
 	"contributors": ["haxeflixel"]


### PR DESCRIPTION
Flixel is more of an engine than a framework, plus we call it engine in the repo description.
